### PR TITLE
[fix] ESLint configuration in example project

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -9,10 +9,8 @@ const program = new Command();
 
 async function generateEslintReport({ absolutePath, fileContent, fileName }, config, outputDir) {
   const eslint = new ESLint({
-    cwd: absolutePath,
     overrideConfig: config,
     errorOnUnmatchedPattern: false,
-    resolvePluginsRelativeTo: resolve(),
     useEslintrc: false,
     cache: false,
   });


### PR DESCRIPTION
This PR fixes the ESLint configuration in example project to work properly when we pointing on target project that is outside of the plugin-preloader directory